### PR TITLE
[feature] Added redirect for react-router-dom in server.js

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -7,12 +7,15 @@ const app = express();
 const port = 3000;
 
 const compiler = webpack(config);
-app.use(require('webpack-dev-middleware')(compiler, {
-  path: config.output.path
-}));
+app.use(require('webpack-dev-middleware')(compiler, { path: config.output.path }));
 app.use(require('webpack-hot-middleware')(compiler));
 
 // Render static index route
 app.use(express.static(path.join(__dirname, '../client')));
+
+// Redirect user back to index.html (used with react-router-dom)
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve(__dirname, '..', 'client/index.html'));
+});
 
 app.listen(port, () => { console.log(`server.js has been served on port: ${port}`); });


### PR DESCRIPTION
Added a redirect back to `index.html` if the current route the front end is trying to hit is not an API end point.